### PR TITLE
Strictly use pd.Series for treating batches

### DIFF
--- a/combat/pycombat.py
+++ b/combat/pycombat.py
@@ -349,6 +349,7 @@ def treat_batches(batch):
         n_batches {int list} -- list of batches lengths
         n_array {int} -- total size of dataset
     """
+    batch = pd.Series(batch)
     n_batch = len(np.unique(batch))  # number of batches
     print("Found "+str(n_batch)+" batches.")
     batches = []  # list of lists, contains the list of position for each batch


### PR DESCRIPTION
## What? 

This PR is linked to issue #16 . Zero Division for list of strings. The fix uses a strict cast to pd.Series for all batch list