### PR TITLE
Use `ddof=1` in np.var for the unbiased estimator of the variance

### DIFF
--- a/combat/test_unit.py
+++ b/combat/test_unit.py
@@ -34,13 +34,13 @@ import pandas as pd
 
 ##########
 # import function used for unit testing
-from pycombat import model_matrix, all_1
+from .pycombat import model_matrix, all_1
 #covariate_model_matrix
-from pycombat import compute_prior, postmean, postvar, it_sol, int_eprior
-from pycombat import check_mean_only, define_batchmod, check_ref_batch, treat_batches, treat_covariates, check_NAs
-from pycombat import calculate_mean_var, calculate_stand_mean
-from pycombat import standardise_data, fit_model, adjust_data
-from pycombat import pycombat
+from .pycombat import compute_prior, postmean, postvar, it_sol, int_eprior
+from .pycombat import check_mean_only, define_batchmod, check_ref_batch, treat_batches, treat_covariates, check_NAs
+from .pycombat import calculate_mean_var, calculate_stand_mean
+from .pycombat import standardise_data, fit_model, adjust_data
+from .pycombat import pycombat
 
 ##########
 print("\n#### Unit Testing for pyComBat ####\n")


### PR DESCRIPTION
As in the original paper, degree of freedom should be 1 when computing variances. The degree of freedom in np.var is set to 0 by default. 