### PR TITLE
Add migration warning to InMoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# MIGRATION WARNING
+
+pyComBat has been merged into [InMoose](https://github.com/inmoose), and is no
+longer maintained as a standalone package.
+This repository remains up for reference, but will no longer be updated.
+
 # pyComBat
 
 pyComBat [1] is a Python 3 implementation of ComBat [2], one of the most widely used tool for correcting technical biases, called batch effects, in microarray expression data.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,12 @@
 Welcome to pyComBat's documentation!
 ====================================
 
+.. warning::
+   This package is now deprecated, and no longer maintained in its standalone
+   version.  It has been merged into `inmoose
+   <https://github.com/epigenelabs/inmoose>`_.  Please consider migrating your
+   code to ``inmoose``.
+
 General Overview
 ----------------
 


### PR DESCRIPTION
Warn the users in the README and the doc that the package has been merged into `inmoose` and will no longer be maintained in its standalone form.

NB: the README warning should appear on PyPI, and the doc warning on readthedocs.org, once we have deployed a new version based on this PR.